### PR TITLE
Sopel's memory objects don't have `.contains()` any more

### DIFF
--- a/sopel_modules/chanlogs/__init__.py
+++ b/sopel_modules/chanlogs/__init__.py
@@ -115,7 +115,7 @@ def setup(bot):
     bot.config.define_section('chanlogs', ChanlogsSection)
 
     # locks for log files
-    if not bot.memory.contains('chanlog_locks'):
+    if 'chanlog_locks' not in bot.memory:
         bot.memory['chanlog_locks'] = sopel.tools.SopelMemoryWithDefault(threading.Lock)
 
 


### PR DESCRIPTION
Well, technically they do until Sopel 8 comes out. But using `SopelMemory.contains()` is already deprecated, and there's no reason for this plugin not to be future-proof.