### PR TITLE
chanlogs: switch from removed `clock.tz` -> `core.default_timezone` setting

### DIFF
--- a/sopel_modules/chanlogs/__init__.py
+++ b/sopel_modules/chanlogs/__init__.py
@@ -72,7 +72,7 @@ def get_datetime(bot):
     if pytz:
         dt = dt.replace(tzinfo=timezone('UTC'))
         if bot.config.chanlogs.localtime:
-            dt = dt.astimezone(timezone(bot.config.clock.tz))
+            dt = dt.astimezone(timezone(bot.config.core.default_timezone))
     if not bot.config.chanlogs.microseconds:
         dt = dt.replace(microsecond=0)
     return dt


### PR DESCRIPTION
This happened a while ago, upstream... Fortunately it was easy to keep this plugin working with a workaround, since Sopel will load settings even if they are not formally defined by a plugin.

Fixes #10.